### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,7 @@
 dnspython>=1.16.0
 argparse
-sys
-time
-datetime
 urllib3
 requests
-webbrowser
-os
 pathlib
-json
-threading
-re 
-queue
 whois
 progress


### PR DESCRIPTION
^ to remove modules that are standard python ones, and hence cause `pip install -r requirements.txt` to fail